### PR TITLE
ignoreSheetNotFound not work correctly

### DIFF
--- a/src/main/java/net/java/amateras/xlsbeans/XLSBeans.java
+++ b/src/main/java/net/java/amateras/xlsbeans/XLSBeans.java
@@ -17,6 +17,7 @@ import net.java.amateras.xlsbeans.processor.FieldProcessorFactory;
 import net.java.amateras.xlsbeans.xml.AnnotationReader;
 import net.java.amateras.xlsbeans.xml.XMLInfo;
 import net.java.amateras.xlsbeans.xml.XMLLoader;
+import net.java.amateras.xlsbeans.xssfconverter.NullWSheetImpl;
 import net.java.amateras.xlsbeans.xssfconverter.WSheet;
 import net.java.amateras.xlsbeans.xssfconverter.WWorkbook;
 import net.java.amateras.xlsbeans.xssfconverter.WorkbookFinder;
@@ -122,7 +123,7 @@ public class XLSBeans {
 //		jxl.Sheet jxlSheet = null;
 		if(sheet.name().length() > 0){
 			WSheet wSheet = w.getSheet(sheet.name());
-			if(wSheet == null){
+			if(wSheet instanceof NullWSheetImpl){
 				throw new SheetNotFoundException(sheet.name());
 			}
 			return new WSheet[]{wSheet};

--- a/src/main/java/net/java/amateras/xlsbeans/xssfconverter/NullWSheetImpl.java
+++ b/src/main/java/net/java/amateras/xlsbeans/xssfconverter/NullWSheetImpl.java
@@ -1,0 +1,32 @@
+package net.java.amateras.xlsbeans.xssfconverter;
+
+/**
+ * Sheet wrapper that indicates no sheet found.
+ *
+ * @author Seiji Sogabe
+ */
+public class NullWSheetImpl implements WSheet {
+
+    public static final NullWSheetImpl INSTANCE = new NullWSheetImpl();
+    
+    public String getName() {
+	return null;
+    }
+
+    public WCell[] getColumn(int i) {
+	return null;
+    }
+
+    public WCell getCell(int column, int row) {
+	return null;
+    }
+
+    public int getColumns() {
+	return 0;
+    }
+
+    public int getRows() {
+	return 0;
+    }
+
+}

--- a/src/main/java/net/java/amateras/xlsbeans/xssfconverter/impl/jxl/JxlWWorkbookImpl.java
+++ b/src/main/java/net/java/amateras/xlsbeans/xssfconverter/impl/jxl/JxlWWorkbookImpl.java
@@ -2,6 +2,7 @@ package net.java.amateras.xlsbeans.xssfconverter.impl.jxl;
 
 import jxl.Sheet;
 import jxl.Workbook;
+import net.java.amateras.xlsbeans.xssfconverter.NullWSheetImpl;
 import net.java.amateras.xlsbeans.xssfconverter.WSheet;
 import net.java.amateras.xlsbeans.xssfconverter.WWorkbook;
 
@@ -20,11 +21,18 @@ public class JxlWWorkbookImpl implements WWorkbook {
 	}
 
 	public WSheet getSheet(int i) {
-		return new JxlWSheetImpl(workbook.getSheet(i));
+		Sheet sheet;
+		try {
+		    sheet = workbook.getSheet(i);
+		} catch (IndexOutOfBoundsException e) {
+		    sheet = null;
+		}
+		return (sheet != null) ? new JxlWSheetImpl(workbook.getSheet(i)) : NullWSheetImpl.INSTANCE;
 	}
 
 	public WSheet getSheet(String name) {
-		return new JxlWSheetImpl(workbook.getSheet(name));
+		Sheet sheet = workbook.getSheet(name);
+		return (sheet != null) ? new JxlWSheetImpl(workbook.getSheet(name)) : NullWSheetImpl.INSTANCE;
 	}
 
 	public WSheet[] getSheets() {

--- a/src/main/java/net/java/amateras/xlsbeans/xssfconverter/impl/xssf/XssfWWorkbookImpl.java
+++ b/src/main/java/net/java/amateras/xlsbeans/xssfconverter/impl/xssf/XssfWWorkbookImpl.java
@@ -1,5 +1,6 @@
 package net.java.amateras.xlsbeans.xssfconverter.impl.xssf;
 
+import net.java.amateras.xlsbeans.xssfconverter.NullWSheetImpl;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 
@@ -22,12 +23,12 @@ public class XssfWWorkbookImpl implements WWorkbook {
 
 	public WSheet getSheet(int i) {
 		Sheet sheet = workbook.getSheetAt(i);
-		return new XssfWSheetImpl(sheet);
+		return (sheet != null) ? new XssfWSheetImpl(sheet) : NullWSheetImpl.INSTANCE;
 	}
 
 	public WSheet getSheet(String name) {
 		Sheet sheet = workbook.getSheet(name);
-		return new XssfWSheetImpl(sheet);
+		return (sheet != null) ? new XssfWSheetImpl(sheet) : NullWSheetImpl.INSTANCE;
 	}
 
 	public WSheet[] getSheets() {

--- a/src/test/java/net/java/amateras/xlsbeans/UserListNoSheet.java
+++ b/src/test/java/net/java/amateras/xlsbeans/UserListNoSheet.java
@@ -1,0 +1,111 @@
+package net.java.amateras.xlsbeans;
+
+import java.util.List;
+
+import net.java.amateras.xlsbeans.annotation.HorizontalRecords;
+import net.java.amateras.xlsbeans.annotation.IterateTables;
+import net.java.amateras.xlsbeans.annotation.LabelledCell;
+import net.java.amateras.xlsbeans.annotation.LabelledCellType;
+import net.java.amateras.xlsbeans.annotation.Sheet;
+import net.java.amateras.xlsbeans.annotation.VerticalRecords;
+
+/**
+ *
+ * @author Naoki Takezoe
+ */
+@Sheet(name="NoSheet")
+public class UserListNoSheet {
+
+	private List<User> horizontalUsers;
+	private List<User> verticalUsers;
+	private String title;
+	private String lastUpdate;
+	private List<Unit> unitUsers;
+	private String actionClassName;
+	private String formClassName;
+	private String labelSkip0;
+	private String labelSkip1;
+
+	public List<Unit> getUnitUsers() {
+		return unitUsers;
+	}
+
+	@IterateTables(tableLabel="部門情報", tableClass=Unit.class, bottom=2)
+	public void setUnitUsers(List<Unit> unitUsers) {
+		this.unitUsers = unitUsers;
+	}
+
+	public List<User> getVerticalUsers() {
+		return verticalUsers;
+	}
+
+	@VerticalRecords(tableLabel="Vertical Table", recordClass=User.class)
+	public void setVerticalUsers(List<User> verticalUsers) {
+		this.verticalUsers = verticalUsers;
+	}
+
+	@HorizontalRecords(tableLabel="User Informations", recordClass=User.class, terminateLabel="Terminate")
+	public void setHorizontalUsers(List<User> users){
+		this.horizontalUsers = users;
+	}
+
+	public List<User> getHorizontalUsers(){
+		return this.horizontalUsers;
+	}
+
+	@LabelledCell(label="Title", type=LabelledCellType.Right)
+	public void setTitle(String title){
+		this.title = title;
+	}
+
+	public String getTitle(){
+		return this.title;
+	}
+
+	@LabelledCell(label="LastUpdated", type=LabelledCellType.Right)
+	public void setLastUpdate(String lastUpdate){
+		this.lastUpdate = lastUpdate;
+	}
+
+	public String getLastUpdate(){
+		return this.lastUpdate;
+	}
+
+	public String getActionClassName() {
+		return actionClassName;
+	}
+
+	@LabelledCell(label="クラス名", headerLabel="アクション", type=LabelledCellType.Right)
+	public void setActionClassName(String actionClassName) {
+		this.actionClassName = actionClassName;
+	}
+
+	public String getFormClassName() {
+		return formClassName;
+	}
+
+	@LabelledCell(label="クラス名", headerLabel="アクションフォーム", type=LabelledCellType.Right)
+	public void setFormClassName(String formClassName) {
+		this.formClassName = formClassName;
+	}
+
+	public String getLabelSkip0() {
+		return labelSkip0;
+	}
+
+	@LabelledCell(label="離れたラベル", type=LabelledCellType.Right)
+	public void setLabelSkip0(String labelSkip0) {
+		this.labelSkip0 = labelSkip0;
+	}
+
+	public String getLabelSkip1() {
+		return labelSkip1;
+	}
+
+	@LabelledCell(label="離れたラベル", type=LabelledCellType.Right, skip=1, range=2)
+	public void setLabelSkip1(String labelSkip1) {
+		this.labelSkip1 = labelSkip1;
+	}
+
+
+}

--- a/src/test/java/net/java/amateras/xlsbeans/XLSBeansTest.java
+++ b/src/test/java/net/java/amateras/xlsbeans/XLSBeansTest.java
@@ -12,6 +12,30 @@ import net.java.amateras.xlsbeans.xssfconverter.WorkbookFinder;
  */
 public class XLSBeansTest extends TestCase {
 
+	public void testSheetNotFound() throws Exception {
+		try {
+			UserListNoSheet userList = new XLSBeans().load(
+					XLSBeansTest.class.getResourceAsStream("example_1.xls"),
+					XLSBeansTest.class.getResourceAsStream("example_1.xml"),
+					UserListNoSheet.class);
+			fail();
+		} catch (SheetNotFoundException e) {
+			// OK 
+		}
+	}
+
+	public void testIgnoreSheetNotFound() throws Exception {
+		XLSBeansConfig config = new XLSBeansConfig();
+		config.setIgnoreSheetNotFound(true);
+			
+		XLSBeans xlsBeans = new XLSBeans();
+		xlsBeans.setConfig(config);
+		UserListNoSheet userList = xlsBeans.load(
+				XLSBeansTest.class.getResourceAsStream("example_1.xls"),
+				XLSBeansTest.class.getResourceAsStream("example_1.xml"),
+				UserListNoSheet.class);
+	}
+	
 	public void test1() throws Exception {
 
 		// System.out.println("*************************************");


### PR DESCRIPTION
ignoreSheetNotFoundを指定しない(false)のときに、@Sheetで存在しないシートを指定した場合、SheetNotFoundExceptionではなく、causeがNPEであるXLSBeanExceptionがスローされます。

XLSBeans.java#124,125で、

```
WSheet wSheet = w.getSheet(sheet.name());
if(wSheet == null){
```

としていますが、w.getSheet()はシートがない場合でもnullは返さないので、SheetNotFoundExceptionはスローされず、その後の処理でNPEがでるようです。
