### PR TITLE
ognl update to 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.0.2</version>
+      <version>3.1.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
**概要**
javassist起因でJDK8だと動作しないケースがある問題の修正

**背景**
以下の条件を満たす場合、エラーが発生することを確認しました。
- JDK8
- 異なるバージョンのjavassistを利用しているライブラリに依存している

具体的にはJava8, PowerMockit, xlsbeansの組み合わせで再現しました。
テストを実施しようとすると下記のようなエラーログが出力されます。

```
java.lang.IllegalStateException: Failed to transform class with name <<実装クラス名>>. Reason: java.io.IOException: invalid constant type: 18

	at org.powermock.core.classloader.MockClassLoader.loadMockClass(MockClassLoader.java:296)
	at org.powermock.core.classloader.MockClassLoader.loadModifiedClass(MockClassLoader.java:204)
	at org.powermock.core.classloader.DeferSupportingClassLoader.loadClass1(DeferSupportingClassLoader.java:89)
	at org.powermock.core.classloader.DeferSupportingClassLoader.loadClass(DeferSupportingClassLoader.java:79)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
	at sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
	at sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
	at sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:439)
	at sun.reflect.annotation.AnnotationParser.parseClassValue(AnnotationParser.java:420)
	at sun.reflect.annotation.AnnotationParser.parseClassArray(AnnotationParser.java:724)
	at sun.reflect.annotation.AnnotationParser.parseArray(AnnotationParser.java:531)
	at sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:355)
	at sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:286)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.lang.Class.createAnnotationData(Class.java:3521)
	at java.lang.Class.annotationData(Class.java:3510)
	at java.lang.Class.getAnnotation(Class.java:3415)
	at java.lang.reflect.AnnotatedElement.isAnnotationPresent(AnnotatedElement.java:258)
	at java.lang.Class.isAnnotationPresent(Class.java:3425)
	at org.powermock.modules.junit4.internal.impl.DelegatingPowerMockRunner$1.call(DelegatingPowerMockRunner.java:102)
	at org.powermock.modules.junit4.internal.impl.DelegatingPowerMockRunner$1.call(DelegatingPowerMockRunner.java:97)
	at org.powermock.modules.junit4.internal.impl.DelegatingPowerMockRunner.withContextClassLoader(DelegatingPowerMockRunner.java:132)
	at org.powermock.modules.junit4.internal.impl.DelegatingPowerMockRunner.createDelegate(DelegatingPowerMockRunner.java:96)
	at org.powermock.modules.junit4.internal.impl.DelegatingPowerMockRunner.<init>(DelegatingPowerMockRunner.java:64)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.powermock.modules.junit4.common.internal.impl.JUnit4TestSuiteChunkerImpl.createDelegatorFromClassloader(JUnit4TestSuiteChunkerImpl.java:172)
	at org.powermock.modules.junit4.common.internal.impl.JUnit4TestSuiteChunkerImpl.createDelegatorFromClassloader(JUnit4TestSuiteChunkerImpl.java:48)
	at org.powermock.tests.utils.impl.AbstractTestSuiteChunkerImpl.createTestDelegators(AbstractTestSuiteChunkerImpl.java:108)
	at org.powermock.modules.junit4.common.internal.impl.JUnit4TestSuiteChunkerImpl.<init>(JUnit4TestSuiteChunkerImpl.java:71)
	at org.powermock.modules.junit4.common.internal.impl.AbstractCommonPowerMockRunner.<init>(AbstractCommonPowerMockRunner.java:36)
	at org.powermock.modules.junit4.PowerMockRunner.<init>(PowerMockRunner.java:34)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:104)
	at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:86)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:101)
	at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:87)
	at com.intellij.junit4.JUnit46ClassesRequestBuilder.collectWrappedRunners(JUnit46ClassesRequestBuilder.java:86)
	at com.intellij.junit4.JUnit46ClassesRequestBuilder.getClassesRequest(JUnit46ClassesRequestBuilder.java:47)
	at com.intellij.junit4.JUnit4TestRunnerUtil.buildRequest(JUnit4TestRunnerUtil.java:90)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:46)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.RuntimeException: java.io.IOException: invalid constant type: 18
	at javassist.CtClassType.getClassFile2(CtClassType.java:203)
	at javassist.CtClassType.makeFieldCache(CtClassType.java:837)
	at javassist.CtClassType.getMembers(CtClassType.java:828)
	at javassist.CtClassType.getMethod0(CtClassType.java:1126)
	at javassist.CtClassType.getMethod(CtClassType.java:1115)
	at javassist.expr.MethodCall.getMethod(MethodCall.java:114)
	at org.powermock.core.transformers.impl.AbstractMainMockTransformer$PowerMockExpressionEditor.edit(AbstractMainMockTransformer.java:347)
	at javassist.expr.ExprEditor.loopBody(ExprEditor.java:191)
	at javassist.expr.ExprEditor.doit(ExprEditor.java:90)
	at javassist.CtClassType.instrument(CtClassType.java:1374)
	at org.powermock.core.transformers.impl.ClassMockTransformer.transformMockClass(ClassMockTransformer.java:65)
	at org.powermock.core.transformers.impl.AbstractMainMockTransformer.transform(AbstractMainMockTransformer.java:62)
	at org.powermock.core.classloader.MockClassLoader.loadMockClass(MockClassLoader.java:277)
	... 55 more
Caused by: java.io.IOException: invalid constant type: 18
	at javassist.bytecode.ConstPool.readOne(ConstPool.java:1027)
	at javassist.bytecode.ConstPool.read(ConstPool.java:970)
	at javassist.bytecode.ConstPool.<init>(ConstPool.java:127)
	at javassist.bytecode.ClassFile.read(ClassFile.java:716)
	at javassist.bytecode.ClassFile.<init>(ClassFile.java:103)
	at javassist.CtClassType.getClassFile2(CtClassType.java:190)
	... 67 more

```
参考：
https://stackoverflow.com/a/30320312
https://bugzilla.redhat.com/show_bug.cgi?id=1089975

**対応**
javassistがJDK8でうまく動作しない不具合は `3.18.1-1` でfixしているので
ognlが javassist `3.20.0-GA` に依存するようになった `3.1.4` まで上げています。

pom編集後 `mvn package`でテストが通ることを確認後
同様にJava8, PowerMockit, xlsbeansでテスト実施時にエラーが発生しないことを確認しました。